### PR TITLE
ログアウトapiの実装

### DIFF
--- a/app/controllers/api/v1/auth/sessions_controller.rb
+++ b/app/controllers/api/v1/auth/sessions_controller.rb
@@ -5,7 +5,6 @@ class Api::V1::Auth::SessionsController < DeviseTokenAuth::SessionsController
   private
 
     def resource_params
-      # binding.pry
       params.permit(:name, :email, :password)
     end
 end

--- a/spec/requests/api/v1/auth/sessions_request_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_request_spec.rb
@@ -51,34 +51,36 @@ RSpec.describe "Sessions", type: :request do
     end
   end
 
-   fdescribe "Userのログアウト DELETE/sign_out" do
+  describe "Userのログアウト DELETE/sign_out" do
     subject { delete(destroy_api_v1_user_session_path, headers: headers) }
-    fcontext "適切なrequest.headersが送信できている" do
+
+    context "適切なrequest.headersが送信できている" do
       let(:current_user) { create(:user) }
       let(:headers) { current_user.create_new_auth_token }
       it "ログアウトできる" do
         # binding.pry
         subject
         # binding.pry
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
         expect(response.headers).not_to include(:headers)
       end
     end
+
     context "不適切なrequest.headerが送信された場合" do
       let(:current_user) { create(:user) }
       let(:headers) do
         {
-          "access-token"=>"",
-          "token-type"=>"",
-          "client"=>"",
-          "expiry"=>"",
-          "uid"=>""
+          "access-token" => "",
+          "token-type" => "",
+          "client" => "",
+          "expiry" => "",
+          "uid" => "",
         }
       end
       it "ログアウトできない" do
         subject
         res = JSON.parse(response.body)
-        expect(response).to have_http_status(404)
+        expect(response).to have_http_status(:not_found)
         expect(res["errors"]).to include("User was not found or was not logged in.")
       end
     end

--- a/spec/requests/api/v1/auth/sessions_request_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_request_spec.rb
@@ -49,100 +49,20 @@ RSpec.describe "Sessions", type: :request do
         expect(response.headers["uid"]).to be_nil
       end
     end
+  end
 
-    ############ 正常系 ############
-    ############ ここは後でするべきところ ##############
-    # context 'context: general authentication via API, ' do
-    #   let(:client) { create(:user) }
-    #   let(:current_user) { create(:user) }
-    #   let(:params) { { name: current_user.name, email: current_user.email, password: current_user.password } }
-    #   let(:headers) { current_user.create_new_auth_token }
-    #   it "ログインできなければ他の機能は使えません" do
-    #     binding.pry
-    #     get api_client_path()
-    #     ## statusがエラーをはく
-    #     expect(response.status).to eq(401)
-    #   end
-    # end
-
-    ######## これはsessionのテストでは不要な機能でした #############
-    # context "request.headerに指定した4つの値が入っている場合" do
-    #   # let(:client) { create(:user) }
-    #   let(:current_user) { create(:user) }
-    #   let(:headers) { current_user.create_new_auth_token }
-    #   let(:params) { { name: current_user.name, email: current_user.email, password: current_user.password } }
-
-    #   it "response.bodyの読み込みに進む" do
-    #     binding.pry
-    #     subject
-    #     binding.pry
-    #     res = JSON.parse(response.body)
-    #     expect(response.headers["uid"]).to be_present
-    #     expect(response.headers["access-token"]).to be_present
-    #     expect(response.headers["client"]).to be_present
-    #     expect(response.headers["expiry"]).to be_present
-    #     expect(response).to have_http_status(:ok)
-    #   end
-    # end
-    # context "response.bodyに適切なパラメーターが入力できている場合" do
-    #   let(:current_user) { create(:user) }
-    #   let(:params) { { name: current_user.name, email: current_user.email, password: current_user.password } }
-    #   let(:headers) { current_user.create_new_auth_token }
-    #   it "ログインできる" do
-    #     binding.pry
-    #     subject
-    #     binding.pry
-    #     res = JSON.parse(response.body)
-    #     expect(res["data"]["name"]).to eq params[:name]
-    #     expect(res["data"]["email"]).to eq params[:email]
-    #     expect(current_user.password).to eq params[:password]
-    #     expect(response).to have_http_status(:ok)
-    #   end
-    # end
-
-    #     ############ 異常系 ############
-    # context "request.header & body に適切な値が入力されていない場合" do
-    # end
-    # fcontext "request.headerのパラメーターが空の場合" do
-    #   let(:current_user) { create(:user) }
-    #   let(:params) { { name: current_user.name, email: current_user.email, password: current_user.password } }
-    #   let(:headers) do
-    #     { "access-token": nil, "token-type": nil, "client": nil, "expiry": nil, "uid": nil }
-    #   end
-    #   it "ログインできない" do
-
-    #     binding.pry
-    #     subject
-    #     binding.pry
-    #     res = JSON.parse(response.body)
-    #     expect(request.headers["access-token"]).to be_nil
-    #     expect(request.headers["token-type"]).to be_nil
-    #     expect(request.headers["client"]).to be_nil
-    #     expect(request.headers["expiry"]).to be_nil
-    #     expect(request.headers["uid"]).to be_nil
-    #     binding.pry
-    #     expect(response).to have_http_status(401)
-    #   end
-    # end
-    # context "response.bodyのパラメーターが空の場合" do
-    #   let(:current_user) { create(:user) }
-    #   let(:params) { { name: nil, email: current_user.email, password: current_user.password } }
-    #   let(:headers) { current_user.create_new_auth_token }
-    #   it "ログインできない" do
-    #     subject
-    #     res = JSON.parse(response.body)
-
-    #     expect(User.where(name: "")).to eq params[:name]
-    #     # expect(response).to have_http_status(:401)
-    #   end
-    #   it "ログインできない" do
-    #     # expect(params[:password]).to eq nil
-    #     # expect(response).to have_http_status(:401)
-    #   end
-    #   # it "ログインできない" do
-    #   #   expect(response.headers["expiry"]).to be_blank
-    #   #   # expect(response).to have_http_status(:401)
-    #   # end
-    # end
+  fdescribe "Userのログアウト DELETE/sign_out" do
+    subject { delete(destroy_api_v1_user_session_path, headers: headers) }
+    context "適切なrequest.headersが送信できている" do
+      let(:current_user) { create(:user) }
+      let(:headers) { current_user.create_new_auth_token }
+      it "ログアウトできる" do
+        # binding.pry
+        subject
+        # binding.pry
+        expect(response).to have_http_status(200)
+        # expect(response.headers["access-token"]).not_to be_nil
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/auth/sessions_request_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_request_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe "Sessions", type: :request do
       it "ログアウトできる" do
         # binding.pry
         subject
-        # binding.pry
+        binding.pry
         expect(response).to have_http_status(200)
-        # expect(response.headers["access-token"]).not_to be_nil
+        expect(response.headers).not_to include(:headers)
       end
     end
   end

--- a/spec/requests/api/v1/auth/sessions_request_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_request_spec.rb
@@ -51,17 +51,35 @@ RSpec.describe "Sessions", type: :request do
     end
   end
 
-  fdescribe "Userのログアウト DELETE/sign_out" do
+   fdescribe "Userのログアウト DELETE/sign_out" do
     subject { delete(destroy_api_v1_user_session_path, headers: headers) }
-    context "適切なrequest.headersが送信できている" do
+    fcontext "適切なrequest.headersが送信できている" do
       let(:current_user) { create(:user) }
       let(:headers) { current_user.create_new_auth_token }
       it "ログアウトできる" do
         # binding.pry
         subject
-        binding.pry
+        # binding.pry
         expect(response).to have_http_status(200)
         expect(response.headers).not_to include(:headers)
+      end
+    end
+    context "不適切なrequest.headerが送信された場合" do
+      let(:current_user) { create(:user) }
+      let(:headers) do
+        {
+          "access-token"=>"",
+          "token-type"=>"",
+          "client"=>"",
+          "expiry"=>"",
+          "uid"=>""
+        }
+      end
+      it "ログアウトできない" do
+        subject
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(404)
+        expect(res["errors"]).to include("User was not found or was not logged in.")
       end
     end
   end


### PR DESCRIPTION
◆ログアウト時のheaderの流れ 
  ※イメージは下記画像の通りです。
  ※以下番号は画像の番号とリンクさせています。
　　①ログアウトはログイン時のアクションなので、request.headersを送る。
　　②ログアウト後はheadersの情報を所持しておく必要がないのでrsponseでは帰ってこない。
　　④再度ログインする場合、再びAPIpost(api_v1_user_session) を叩けば新規tokenが発行され、
　　　response.headersとして返ってくる。

<img width="1126" alt="スクリーンショット 2021-04-03 23 52 33" src="https://user-images.githubusercontent.com/69076028/113482046-c5a90500-94d7-11eb-9e19-654e3adb6455.png">
